### PR TITLE
Arreglo para que la parte del sidebar sea un poco mas  adaptable

### DIFF
--- a/src/components/LayoutMain.vue
+++ b/src/components/LayoutMain.vue
@@ -10,7 +10,7 @@ import SideBarMenu from './SideBarMenu.vue';
     </el-header>
     
     <el-container>
-      <el-aside width="250px">
+      <el-aside width="auto">
         <SideBarMenu />
       </el-aside>
 

--- a/src/components/SideBarMenu.vue
+++ b/src/components/SideBarMenu.vue
@@ -35,9 +35,9 @@
   
 
   
-  .el-menu-vertical-demo {
-    width: 250px;
-    min-height: 100%;
-  }
+  .el-menu-vertical-demo{
+  width: fit-content;
+  min-height: 100%;
+}
   </style>
   


### PR DESCRIPTION
Instructor, muy buenas tardes. El proyecto frontend, tenia un sidebar estatico, lo que limita la composicion en el caso de que el elemento clickeable ( item ) sea mayor a el ancho de el sidebar, de tal manera que aplique dos cambios.

1.  En el componente llamado LayoutMain tenemos un aside con el ancho de auto **<el-aside width="auto">** .
2. En el componente SidebarMenu tenemos que, para el menu vertical se debe tener un ancho que sea adaptable a el tamano del item con el nombre mas largo, por lo tanto. 
.el-menu-vertical-demo{
  width: fit-content;
  min-height: 100%;
}

Hago esto debido a que en el caso de el proyecto TrueMaster, tengo items con titulos que ocupan mas de los 250px anteriormente adheridos, por lo que no quedaba bien, ahora con esta correccion, si pueden ocupar el ancho que les indico.

Por cierto, le pido disculpas por no usar tildes, debido a que formatee recientemente mi PC y puse el teclado en ingles, es esta la unica forma en la que se me hace facil escribir.